### PR TITLE
fix 136: visualisation remove capitalise from h1

### DIFF
--- a/src/components/banner/styles.tsx
+++ b/src/components/banner/styles.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import styled from "@emotion/styled";
+import React from 'react';
+import styled from '@emotion/styled';
 
 type ImageProps = {
   className: string;
@@ -25,7 +25,6 @@ export const BannerWrapper = styled.div<ImageProps>`
       font-size: 3rem;
       line-height: 3rem;
       font-weight: 700;
-      text-transform: capitalize;
       color: #fff;
     }
 


### PR DESCRIPTION
<img width="1423" alt="Zrzut ekranu 2023-05-16 o 16 37 11" src="https://github.com/amplience/dc-visualization-get-started/assets/119587095/5f25b96f-6a0e-4496-9a5d-b2bb58e89781">
